### PR TITLE
Turn off overpass

### DIFF
--- a/build.js
+++ b/build.js
@@ -1341,23 +1341,25 @@ function init() {
         mapillaryImageKey = node.key;
     });
 
-    map.on('dragend', function(event) {
-      if (map.getZoom() > 14) {
-        getTurnRestrictions(function(error, data) {
-          if (error) return console.error(error);
-          map.getSource('osmTurnRestrictions').setData(data);
-        });
-      }
-    });
-
-    map.on('zoomend', function(event) {
-      if (map.getZoom() > 14) {
-        getTurnRestrictions(function(error, data) {
-          if (error) return console.error(error);
-          map.getSource('osmTurnRestrictions').setData(data);
-        })
-      }
-    });
+    // Temporary: Turn off overpass queries
+    //
+    // map.on('dragend', function(event) {
+    //   if (map.getZoom() > 14) {
+    //     getTurnRestrictions(function(error, data) {
+    //       if (error) return console.error(error);
+    //       map.getSource('osmTurnRestrictions').setData(data);
+    //     });
+    //   }
+    // });
+    //
+    // map.on('zoomend', function(event) {
+    //   if (map.getZoom() > 14) {
+    //     getTurnRestrictions(function(error, data) {
+    //       if (error) return console.error(error);
+    //       map.getSource('osmTurnRestrictions').setData(data);
+    //     })
+    //   }
+    // });
 }
 
 

--- a/index.js
+++ b/index.js
@@ -1296,23 +1296,25 @@ function init() {
         mapillaryImageKey = node.key;
     });
 
-    map.on('dragend', function(event) {
-      if (map.getZoom() > 14) {
-        getTurnRestrictions(function(error, data) {
-          if (error) return console.error(error);
-          map.getSource('osmTurnRestrictions').setData(data);
-        });
-      }
-    });
-
-    map.on('zoomend', function(event) {
-      if (map.getZoom() > 14) {
-        getTurnRestrictions(function(error, data) {
-          if (error) return console.error(error);
-          map.getSource('osmTurnRestrictions').setData(data);
-        })
-      }
-    });
+    // Temporary: Turn off overpass queries
+    //
+    // map.on('dragend', function(event) {
+    //   if (map.getZoom() > 14) {
+    //     getTurnRestrictions(function(error, data) {
+    //       if (error) return console.error(error);
+    //       map.getSource('osmTurnRestrictions').setData(data);
+    //     });
+    //   }
+    // });
+    //
+    // map.on('zoomend', function(event) {
+    //   if (map.getZoom() > 14) {
+    //     getTurnRestrictions(function(error, data) {
+    //       if (error) return console.error(error);
+    //       map.getSource('osmTurnRestrictions').setData(data);
+    //     })
+    //   }
+    // });
 }
 
 


### PR DESCRIPTION
Removing overpass queries for some time as it's slowing down the map. Using the community instance instead would be difficult, since we have a lot people working in parallel. 

cc: @batpad @geohacker 